### PR TITLE
PLATUI-1722: url encode path and query in location header

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/language/LanguageController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/language/LanguageController.scala
@@ -76,8 +76,8 @@ abstract class LanguageController(languageUtils: LanguageUtils, cc: ControllerCo
   private def asRelativeUrl(url: String): Option[String] =
     for {
       uri      <- Try(new URI(url)).toOption
-      path     <- Option(uri.getPath).filterNot(_.isEmpty)
-      query    <- Option(uri.getQuery).map("?" + _).orElse(Some(""))
+      path     <- Option(uri.getRawPath).filterNot(_.isEmpty)
+      query    <- Option(uri.getRawQuery).map("?" + _).orElse(Some(""))
       fragment <- Option(uri.getRawFragment).map("#" + _).orElse(Some(""))
     } yield s"$path$query$fragment"
 

--- a/src/test/scala/uk/gov/hmrc/play/language/LanguageControllerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/language/LanguageControllerSpec.scala
@@ -143,6 +143,18 @@ class LanguageControllerSpec extends PlaySpec with PlayRunners {
         redirectLocation(res) must be(Some("/path?a=b#foo"))
       }
     }
+
+    "url encode all parts of the url in location header" in {
+      running() { app =>
+        val sut     = app.injector.instanceOf[TestLanguageController]
+        val request = FakeRequest().withHeaders(
+          REFERER -> s"https://www.tax.service.gov.uk/path%20with%20space?query=%C2%A320#%C2%A320"
+        )
+        val res     = sut.switchToLanguage("english")(request)
+        status(res)           must be(SEE_OTHER)
+        redirectLocation(res) must be(Some("/path%20with%20space?query=%C2%A320#%C2%A320"))
+      }
+    }
   }
 
 }


### PR DESCRIPTION
If you changed language twice on a page with special characters
in the path or query param then you would trigger an exception after
trying to send improperly encoded special characters in the referrer
or location header.

Example of problem:
![CleanShot 2022-05-12 at 11 35 54](https://user-images.githubusercontent.com/100650/168052371-de6c781c-9ffa-4f3c-8c68-2c867fa74231.gif)

Example after fixing:
![CleanShot 2022-05-12 at 11 33 51](https://user-images.githubusercontent.com/100650/168052470-82850799-cdcf-4173-bc9d-a3dbc6347806.gif)
